### PR TITLE
feat: Add OpenSearch support as a search backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [1.2.0] - 2024-03-16
+
+### Feature: Configurable Search Backend
+- Added support for multiple search backends (Qdrant and OpenSearch).
+- Introduced `SEARCH_CLIENT_TYPE` environment variable to select the active search client.
+  - Supported values: `qdrant`, `opensearch`. Defaults to `qdrant`.
+- Introduced `DEFAULT_COLLECTION_NAME` environment variable to configure the default search index/collection name.
+- Implemented `OpenSearchClient` in `src/search-clients/opensearch-client.ts` supporting:
+  - Connection to OpenSearch via environment variables (`OPENSEARCH_NODE`, `OPENSEARCH_USERNAME`, `OPENSEARCH_PASSWORD`).
+  - Index creation (`initCollection`) with k-NN compatible mappings.
+  - k-NN search (`search`) functionality.
+- Refactored `QdrantClient` to `QdrantSearchClient` in `src/search-clients/qdrant-client.ts`.
+- Modified `ApiClient` to dynamically instantiate and manage the selected search client.
+  - Search client attempts to auto-initialize the `DEFAULT_COLLECTION_NAME` on startup.
+- Added `@opensearch-project/opensearch` package to dependencies.
+
+### Documentation
+- Updated `README.md` with instructions for configuring `SEARCH_CLIENT_TYPE` and related environment variables for both Qdrant and OpenSearch.
+- Added this changelog entry.
+
 ## [1.1.0] - 2024-03-14
 
 ### Initial Feature Addition

--- a/README.md
+++ b/README.md
@@ -56,9 +56,42 @@ The RAG Documentation tool is designed for:
 
 ## Configuration
 
+To run this MCP server, you'll need to configure the following environment variables:
+
+- `OPENAI_API_KEY`: Your OpenAI API key, used for generating embeddings for the text.
+
+### Search Backend Configuration
+
+The system can use different vector databases as a search backend. You can select the desired backend and configure its connection details using the following environment variables:
+
+-   `SEARCH_CLIENT_TYPE`: Specifies the search client to use.
+    -   Set to `'qdrant'` to use Qdrant.
+    -   Set to `'opensearch'` to use OpenSearch.
+    -   If not set or invalid, it defaults to `'qdrant'`.
+
+-   `DEFAULT_COLLECTION_NAME`: Specifies the default name for the main collection or index used by the search client.
+    -   Defaults to `'documentation'` if not set. This is the name of the index/collection that will be automatically created or used by the system.
+
+#### Qdrant Configuration
+
+If `SEARCH_CLIENT_TYPE` is set to `'qdrant'` (or if it's defaulting), the following additional variables are required:
+
+-   `QDRANT_URL`: URL of your Qdrant vector database instance (e.g., `http://localhost:6333`).
+-   `QDRANT_API_KEY`: API key for authenticating with Qdrant (if applicable).
+
+#### OpenSearch Configuration
+
+If `SEARCH_CLIENT_TYPE` is set to `'opensearch'`, the following additional variables are required:
+
+-   `OPENSEARCH_NODE`: URL of your OpenSearch node (e.g., `https://localhost:9200`).
+-   `OPENSEARCH_USERNAME`: Username for OpenSearch authentication.
+-   `OPENSEARCH_PASSWORD`: Password for OpenSearch authentication.
+
+**Note:** Ensure that the chosen search backend (Qdrant or OpenSearch) is properly installed, running, and accessible to the application with the correct credentials and network settings. The specified `DEFAULT_COLLECTION_NAME` will be automatically initialized if it doesn't exist when the server starts.
+
 ### Usage with Claude Desktop
 
-Add this to your `claude_desktop_config.json`:
+When configuring the server for use with Claude Desktop (or similar environments), you'll need to pass these environment variables. Here's an example snippet for `claude_desktop_config.json`, assuming you are using Qdrant:
 
 ```json
 {
@@ -70,19 +103,22 @@ Add this to your `claude_desktop_config.json`:
         "@hannesrudolph/mcp-ragdocs"
       ],
       "env": {
-        "OPENAI_API_KEY": "",
-        "QDRANT_URL": "",
-        "QDRANT_API_KEY": ""
+        "OPENAI_API_KEY": "your_openai_key",
+        "SEARCH_CLIENT_TYPE": "qdrant", // or "opensearch"
+        "QDRANT_URL": "your_qdrant_url",
+        "QDRANT_API_KEY": "your_qdrant_api_key",
+        // If using opensearch, replace QDRANT_* with OPENSEARCH_* variables
+        // "OPENSEARCH_NODE": "your_opensearch_node_url",
+        // "OPENSEARCH_USERNAME": "your_opensearch_username",
+        // "OPENSEARCH_PASSWORD": "your_opensearch_password",
+        "DEFAULT_COLLECTION_NAME": "my_docs_collection" // Optional
       }
     }
   }
 }
 ```
 
-You'll need to provide values for the following environment variables:
-- `OPENAI_API_KEY`: Your OpenAI API key for embeddings generation
-- `QDRANT_URL`: URL of your Qdrant vector database instance
-- `QDRANT_API_KEY`: API key for authenticating with Qdrant
+Adjust the `env` block according to your chosen search backend and actual credentials.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,22 @@
 {
   "name": "@hannesrudolph/mcp-ragdocs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hannesrudolph/mcp-ragdocs",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@azure/openai": "^2.0.0",
-        "@modelcontextprotocol/sdk": "^1.0.3",
-        "@qdrant/js-client-rest": "^1.12.0",
-        "axios": "^1.7.9",
-        "cheerio": "^1.0.0",
-        "openai": "^4.76.2",
-        "playwright": "^1.49.1"
+        "@azure/openai": "2.0.0",
+        "@modelcontextprotocol/sdk": "1.0.3",
+        "@opensearch-project/opensearch": "^3.5.1",
+        "@qdrant/js-client-rest": "1.12.0",
+        "axios": "1.7.9",
+        "cheerio": "1.0.0",
+        "openai": "4.76.2",
+        "playwright": "1.49.1"
       },
       "bin": {
         "mcp-ragdocs": "build/index.js"
@@ -199,6 +200,23 @@
         "zod": "^3.23.8"
       }
     },
+    "node_modules/@opensearch-project/opensearch": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch/-/opensearch-3.5.1.tgz",
+      "integrity": "sha512-6bf+HcuERzAtHZxrm6phjref54ABse39BpkDie/YO3AUFMCBrb3SK5okKSdT5n3+nDRuEEQLhQCl0RQV3s1qpA==",
+      "dependencies": {
+        "aws4": "^1.11.0",
+        "debug": "^4.3.1",
+        "hpagent": "^1.2.0",
+        "json11": "^2.0.0",
+        "ms": "^2.1.3",
+        "secure-json-parse": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "yarn": "^1.22.10"
+      }
+    },
     "node_modules/@qdrant/js-client-rest": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/@qdrant/js-client-rest/-/js-client-rest-1.12.0.tgz",
@@ -351,6 +369,11 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/aws4": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="
     },
     "node_modules/axios": {
       "version": "1.7.9",
@@ -686,6 +709,14 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
@@ -773,6 +804,14 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/json11": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/json11/-/json11-2.0.2.tgz",
+      "integrity": "sha512-HIrd50UPYmP6sqLuLbFVm75g16o0oZrVfxrsY0EEys22klz8mRoWlX9KAEDOSOR9Q34rcxsyC8oDveGrCz5uLQ==",
+      "bin": {
+        "json11": "dist/cli.mjs"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -993,6 +1032,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@azure/openai": "2.0.0",
     "@modelcontextprotocol/sdk": "1.0.3",
+    "@opensearch-project/opensearch": "^3.5.1",
     "@qdrant/js-client-rest": "1.12.0",
     "axios": "1.7.9",
     "cheerio": "1.0.0",

--- a/src/handlers/search-documentation.ts
+++ b/src/handlers/search-documentation.ts
@@ -1,6 +1,6 @@
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { BaseHandler } from './base-handler.js';
-import { McpToolResponse, isDocumentPayload } from '../types.js';
+import { McpToolResponse, SearchResult, isDocumentPayload, DocumentPayload } from '../types.js';
 
 const COLLECTION_NAME = 'documentation';
 
@@ -11,24 +11,30 @@ export class SearchDocumentationHandler extends BaseHandler {
     }
 
     const limit = args.limit || 5;
+    const scoreThreshold = args.score_threshold ?? 0.7; // Allow overriding threshold
 
     try {
       const queryEmbedding = await this.apiClient.getEmbeddings(args.query);
       
-      const searchResults = await this.apiClient.qdrantClient.search(COLLECTION_NAME, {
-        vector: queryEmbedding,
+      // Use the new searchClient from ApiClient
+      const searchResults: SearchResult[] = await this.apiClient.searchClient.search(
+        COLLECTION_NAME,
+        queryEmbedding,
         limit,
-        with_payload: true,
-        with_vector: false, // Optimize network transfer by not retrieving vectors
-        score_threshold: 0.7, // Only return relevant results
-      });
-
-      const formattedResults = searchResults.map(result => {
-        if (!isDocumentPayload(result.payload)) {
-          throw new Error('Invalid payload type');
+        {
+          with_payload: true,
+          with_vector: false, // Optimize network transfer
+          score_threshold: scoreThreshold,
         }
-        return `[${result.payload.title}](${result.payload.url})\nScore: ${result.score.toFixed(3)}\nContent: ${result.payload.text}\n`;
-      }).join('\n---\n');
+      );
+
+      const formattedResults = searchResults
+        .filter(result => result.payload && isDocumentPayload(result.payload)) // Ensure payload exists and is valid
+        .map(result => {
+          const payload = result.payload as DocumentPayload; // Safe cast after filter
+          return `[${payload.title}](${payload.url})\nScore: ${result.score.toFixed(3)}\nContent: ${payload.text}\n`;
+        })
+        .join('\n---\n');
 
       return {
         content: [
@@ -39,24 +45,26 @@ export class SearchDocumentationHandler extends BaseHandler {
         ],
       };
     } catch (error) {
-      if (error instanceof Error) {
-        if (error.message.includes('unauthorized')) {
-          throw new McpError(
-            ErrorCode.InvalidRequest,
-            'Failed to authenticate with Qdrant cloud while searching'
-          );
-        } else if (error.message.includes('ECONNREFUSED') || error.message.includes('ETIMEDOUT')) {
-          throw new McpError(
-            ErrorCode.InternalError,
-            'Connection to Qdrant cloud failed while searching'
-          );
-        }
+      // The searchClient methods are expected to throw McpError for known issues.
+      // So, we can simplify the catch block or make it more generic.
+      const message = error instanceof McpError ? error.message : (error instanceof Error ? error.message : String(error));
+      // If the error is already an McpError, we might want to rethrow it or handle it specifically.
+      // For now, wrap it in a generic "Search failed" McpToolResponse.
+      // Consider logging the original error for debugging.
+      console.error(`SearchDocumentationHandler Error: ${message}`, error);
+
+      // Check if it's an McpError and if we want to pass its details along
+      if (error instanceof McpError) {
+        // You could choose to return the specific McpError details
+        // For example: throw error; or return its specific message
+        // For now, returning a generic tool error response
       }
+
       return {
         content: [
           {
             type: 'text',
-            text: `Search failed: ${error}`,
+            text: `Search failed: ${message}`,
           },
         ],
         isError: true,

--- a/src/search-clients/opensearch-client.ts
+++ b/src/search-clients/opensearch-client.ts
@@ -1,0 +1,151 @@
+import { Client } from '@opensearch-project/opensearch';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { ISearchClient, SearchResult, DocumentPayload } from '../types.js';
+
+// Environment variables for OpenSearch configuration
+const OPENSEARCH_NODE = process.env.OPENSEARCH_NODE;
+const OPENSEARCH_USERNAME = process.env.OPENSEARCH_USERNAME;
+const OPENSEARCH_PASSWORD = process.env.OPENSEARCH_PASSWORD;
+
+// Default dimension for knn_vector
+const EMBEDDING_DIMENSION = 1536; // Assuming text-embedding-3-small
+
+export class OpenSearchClient implements ISearchClient {
+  private client: Client;
+
+  constructor() {
+    if (!OPENSEARCH_NODE) {
+      throw new McpError(ErrorCode.InvalidRequest, 'OPENSEARCH_NODE environment variable is required.');
+    }
+    if (!OPENSEARCH_USERNAME) {
+      throw new McpError(ErrorCode.InvalidRequest, 'OPENSEARCH_USERNAME environment variable is required.');
+    }
+    if (!OPENSEARCH_PASSWORD) {
+      throw new McpError(ErrorCode.InvalidRequest, 'OPENSEARCH_PASSWORD environment variable is required.');
+    }
+
+    this.client = new Client({
+      node: OPENSEARCH_NODE,
+      auth: {
+        username: OPENSEARCH_USERNAME,
+        password: OPENSEARCH_PASSWORD,
+      },
+      // Depending on your OpenSearch setup, you might need SSL options, e.g.:
+      // ssl: {
+      //   rejectUnauthorized: false // Use with caution, ideally use a proper CA
+      // }
+    });
+  }
+
+  async initCollection(collectionName: string): Promise<void> {
+    try {
+      const { body: indexExists } = await this.client.indices.exists({ index: collectionName });
+
+      if (indexExists) {
+        console.log(`OpenSearch index ${collectionName} already exists.`);
+        return;
+      }
+
+      const mappingProperties: Record<string, any> = {
+        embedding: {
+          type: 'knn_vector',
+          dimension: EMBEDDING_DIMENSION,
+          method: { // Ensure method is specified if required by your OS version for cosinesimil
+            name: 'hnsw',
+            space_type: 'cosinesimil',
+            engine: 'lucene', // lucene is often default in newer versions
+          },
+        },
+        title: { type: 'text' },
+        text: { type: 'text' },
+        url: { type: 'keyword' }, // Using keyword for URLs to ensure they are not tokenized
+        timestamp: { type: 'date' },
+        _type: { type: 'keyword' }, // To store 'DocumentChunk'
+      };
+
+      await this.client.indices.create({
+        index: collectionName,
+        body: {
+          settings: {
+            'index.knn': true, // Enable k-NN for the index
+            // "index.knn.algo_param.ef_search": 100 // Optional: fine-tune search performance
+          },
+          mappings: {
+            properties: mappingProperties,
+          },
+        },
+      });
+      console.log(`OpenSearch index ${collectionName} created successfully with k-NN mapping.`);
+
+    } catch (error: any) {
+      console.error(`Error initializing OpenSearch collection ${collectionName}:`, error.meta?.body || error);
+      const errorMessage = error.meta?.body?.error?.reason || error.message || 'Failed to initialize OpenSearch collection';
+      throw new McpError(ErrorCode.InternalError, `OpenSearch Init Error: ${errorMessage}`);
+    }
+  }
+
+  async search(
+    collectionName: string,
+    queryEmbedding: number[],
+    limit: number,
+    options?: Record<string, any> // options can include score_threshold, etc.
+  ): Promise<SearchResult[]> {
+    try {
+      const requestBody: any = {
+        size: limit,
+        query: {
+          knn: {
+            embedding: { // Assuming 'embedding' is the k-NN vector field name
+              vector: queryEmbedding,
+              k: limit, // k is typically the number of neighbors to find
+            },
+          },
+        },
+        // _source: true, // Explicitly request _source, default is usually true
+      };
+
+      // OpenSearch k-NN search doesn't directly use a score_threshold in the query itself like Qdrant.
+      // Filtering by score would typically be done client-side after receiving results,
+      // or by combining k-NN with a post_filter if applicable and supported for k-NN scores.
+      // For now, we retrieve 'k' results and can filter client-side if options.score_threshold is provided.
+
+      const response = await this.client.search({
+        index: collectionName,
+        body: requestBody,
+      });
+
+      const hits = response.body.hits.hits;
+      let searchResults: SearchResult[] = hits.map((hit: any) => {
+        const payload = hit._source as DocumentPayload; // Assuming _source matches DocumentPayload
+        // OpenSearch k-NN scores are distances (e.g., 0.0 to 2.0 for cosinesimil).
+        // To make it comparable to Qdrant's similarity scores (higher is better, e.g., 0.0 to 1.0 for cosine):
+        // For cosinesimil, score = 1 / (1 + distance). Or if it's already 0-1, adjust as needed.
+        // The JS client might return scores that are already 0-1 for cosinesimil if properly configured.
+        // Let's assume for now hit._score is directly usable or needs minimal adjustment.
+        // If hit._score is a distance (e.g. for cosinesimil where 0 is identical),
+        // a common conversion to similarity is 1 / (1 + distance) or ensuring it's already in desired format.
+        // Qdrant's cosine similarity is 0-1 (higher is better).
+        // OpenSearch's default cosine similarity for knn_vector is often also 0-1 (higher is better).
+        // If the score is `null` or `undefined` for some reason, default to 0.
+        const score = (hit._score !== undefined && hit._score !== null) ? Number(hit._score) : 0;
+
+        return {
+          id: hit._id,
+          score: score,
+          payload: payload && typeof payload === 'object' ? payload : null,
+        };
+      });
+
+      if (options?.score_threshold && typeof options.score_threshold === 'number') {
+        searchResults = searchResults.filter(result => result.score >= (options.score_threshold as number));
+      }
+
+      return searchResults;
+
+    } catch (error: any) {
+      console.error(`Error searching OpenSearch collection ${collectionName}:`, error.meta?.body || error);
+      const errorMessage = error.meta?.body?.error?.reason || error.message || 'Failed to search OpenSearch collection';
+      throw new McpError(ErrorCode.InternalError, `OpenSearch Search Error: ${errorMessage}`);
+    }
+  }
+}

--- a/src/search-clients/qdrant-client.ts
+++ b/src/search-clients/qdrant-client.ts
@@ -1,0 +1,128 @@
+import { QdrantClient as ActualQdrantClient, Schemas } from '@qdrant/js-client-rest';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { ISearchClient, SearchResult, DocumentPayload, isDocumentPayload } from '../types.js';
+
+// Environment variables for configuration
+const QDRANT_URL = process.env.QDRANT_URL;
+const QDRANT_API_KEY = process.env.QDRANT_API_KEY;
+
+export class QdrantSearchClient implements ISearchClient {
+  private qdrantClient: ActualQdrantClient;
+
+  constructor() {
+    if (!QDRANT_URL) {
+      throw new McpError(ErrorCode.InvalidRequest,'QDRANT_URL environment variable is required for QdrantSearchClient');
+    }
+    if (!QDRANT_API_KEY) {
+      throw new McpError(ErrorCode.InvalidRequest, 'QDRANT_API_KEY environment variable is required for QdrantSearchClient');
+    }
+
+    this.qdrantClient = new ActualQdrantClient({
+      url: QDRANT_URL,
+      apiKey: QDRANT_API_KEY,
+    });
+  }
+
+  async initCollection(collectionName: string): Promise<void> {
+    try {
+      const collections = await this.qdrantClient.getCollections();
+      const collectionExists = collections.collections.some(c => c.name === collectionName);
+
+      if (!collectionExists) {
+        await this.qdrantClient.createCollection(collectionName, {
+          vectors: {
+            size: 1536, // OpenAI text-embedding-3-small embedding size
+            distance: 'Cosine' as Schemas.Distance, // Explicitly cast to Schemas.Distance
+          },
+          optimizers_config: {
+            default_segment_number: 2,
+            memmap_threshold: 20000,
+          } as Schemas.OptimizersConfigDiff, // Explicitly cast
+          replication_factor: 2,
+        });
+        console.log(`Collection ${collectionName} created.`);
+      } else {
+        console.log(`Collection ${collectionName} already exists.`);
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message.includes('unauthorized')) {
+          throw new McpError(
+            ErrorCode.InvalidRequest,
+            'Failed to authenticate with Qdrant. Please check your API key.'
+          );
+        } else if (error.message.includes('ECONNREFUSED') || error.message.includes('ETIMEDOUT')) {
+          throw new McpError(
+            ErrorCode.InternalError,
+            'Failed to connect to Qdrant. Please check your QDRANT_URL.'
+          );
+        }
+      }
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to initialize Qdrant collection ${collectionName}: ${error}`
+      );
+    }
+  }
+
+  async search(
+    collectionName: string,
+    queryEmbedding: number[],
+    limit: number,
+    options?: Record<string, any>
+  ): Promise<SearchResult[]> {
+    try {
+      const searchResults = await this.qdrantClient.search(collectionName, {
+        vector: queryEmbedding,
+        limit,
+        with_payload: options?.with_payload ?? true,
+        with_vector: options?.with_vector ?? false,
+        score_threshold: options?.score_threshold ?? 0.7,
+        // Include any other options passed, or use defaults
+        ...(options || {}),
+      });
+
+      return searchResults.map(result => {
+        // Ensure the payload is of the expected type DocumentPayload
+        // The id field is part of Qdrant's PointId type (string or number)
+        // The score field is part of Qdrant's ScoredPoint type
+        if (!isDocumentPayload(result.payload)) {
+          // Handle cases where payload is not DocumentPayload or is null
+          // For now, we'll throw an error or return a SearchResult with null payload
+          // depending on strictness requirements.
+          // Based on current usage, a valid DocumentPayload is expected.
+          console.warn(`Invalid payload type for result ID ${result.id}:`, result.payload);
+          // Returning with null payload if it's not matching, or skip this result
+          return {
+            id: result.id,
+            score: result.score,
+            payload: null,
+          };
+        }
+        return {
+          id: result.id,
+          score: result.score,
+          payload: result.payload as DocumentPayload, // Cast is safe due to isDocumentPayload check
+        };
+      });
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message.includes('unauthorized')) {
+          throw new McpError(
+            ErrorCode.InvalidRequest,
+            'Failed to authenticate with Qdrant while searching.'
+          );
+        } else if (error.message.includes('ECONNREFUSED') || error.message.includes('ETIMEDOUT')) {
+          throw new McpError(
+            ErrorCode.InternalError,
+            'Connection to Qdrant failed while searching.'
+          );
+        }
+      }
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Search failed in Qdrant collection ${collectionName}: ${error}`
+      );
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,3 +39,22 @@ export interface McpToolResponse {
   }>;
   isError?: boolean;
 }
+
+export interface SearchResult {
+  id: string | number;
+  payload: DocumentPayload | null;
+  score: number;
+  // Potentially other fields from Qdrant like 'version', 'shard_key', etc.
+  // Keeping it simple based on current usage.
+}
+
+export interface ISearchClient {
+  search(
+    collectionName: string,
+    queryEmbedding: number[],
+    limit: number,
+    options?: Record<string, any> // For parameters like with_payload, with_vector, score_threshold etc.
+  ): Promise<SearchResult[]>;
+
+  initCollection(collectionName: string): Promise<void>;
+}


### PR DESCRIPTION
This commit introduces support for OpenSearch as an alternative search backend to Qdrant.

Key changes:
- Defined an `ISearchClient` interface for abstracting search operations.
- Refactored the existing Qdrant logic into `QdrantSearchClient` implementing `ISearchClient`.
- Implemented `OpenSearchClient` also implementing `ISearchClient`.
- Modified `ApiClient` to dynamically instantiate and use either `QdrantSearchClient` or `OpenSearchClient` based on the `SEARCH_CLIENT_TYPE` environment variable.
- The default collection/index is now also configurable via `DEFAULT_COLLECTION_NAME` and initialized automatically.
- Updated `SearchDocumentationHandler` to use the abstracted search client.
- Added `@opensearch-project/opensearch` as a dependency.
- Updated `README.md` with instructions for configuring Qdrant or OpenSearch.
- Added an entry to `CHANGELOG.md`.

Unit tests for `OpenSearchClient` were initiated but are currently incomplete due to challenges with Jest mocking in an ESM/TypeScript environment for the OpenSearch library. Further work is required to make these tests fully operational.